### PR TITLE
feat: add health check command

### DIFF
--- a/src-tauri/src/commands/health.rs
+++ b/src-tauri/src/commands/health.rs
@@ -1,0 +1,134 @@
+use crate::core::models::CommandStatus;
+use crate::storage::persistence;
+use crate::AppState;
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::Ordering;
+use tauri::State;
+
+/// Aggregated app health information for diagnostics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthCheckResponse {
+    pub status: String,
+    pub search_session_status: String,
+    pub active_search_id: Option<u64>,
+    pub index_status: String,
+    pub index_entries: usize,
+    pub index_roots: usize,
+    pub index_version_mismatch: bool,
+    pub index_rebuild_in_progress: bool,
+    pub index_rebuild_entries_count: usize,
+    pub settings_status: String,
+    pub cache_status: String,
+    pub storage_status: String,
+    pub storage_path: String,
+    pub storage_message: Option<String>,
+}
+
+/// Returns a snapshot of app/backend subsystem health.
+#[tauri::command]
+pub fn health_check(state: State<'_, AppState>) -> Result<HealthCheckResponse, String> {
+    health_check_inner(state.inner())
+}
+
+fn health_check_inner(state: &AppState) -> Result<HealthCheckResponse, String> {
+    let search_snapshot = crate::lock_mutex!(state.search_session, "search_session").snapshot();
+    let search_session_status = command_status_label(&search_snapshot.status).to_string();
+    let cache_status = if search_snapshot.active_search_id.is_some() {
+        "active"
+    } else {
+        "idle"
+    }
+    .to_string();
+
+    let settings_snapshot = crate::lock_mutex!(state.settings, "settings").snapshot();
+    let settings_ok = !settings_snapshot.language.trim().is_empty()
+        && !settings_snapshot.date_format.trim().is_empty()
+        && !settings_snapshot.size_unit.trim().is_empty()
+        && settings_snapshot.max_history_entries > 0;
+    let settings_status = if settings_ok { "ok" } else { "invalid" }.to_string();
+
+    let index_rebuild_in_progress = state.index_rebuild_in_progress.load(Ordering::Acquire);
+    let index_rebuild_entries_count = state.index_rebuild_entries.load(Ordering::Acquire);
+    let (index_status, index_entries, index_roots, index_version_mismatch) = {
+        let index = crate::lock_mutex!(state.index, "index");
+        let snapshot = index.snapshot();
+        let version_mismatch = index.version_mismatch();
+        let status = if index_rebuild_in_progress {
+            "in_progress"
+        } else if version_mismatch {
+            "version_mismatch"
+        } else if snapshot.entries.is_empty() {
+            "empty"
+        } else {
+            "ready"
+        };
+        (
+            status.to_string(),
+            snapshot.entries.len(),
+            snapshot.roots.len(),
+            version_mismatch,
+        )
+    };
+
+    let storage_path = persistence::data_dir();
+    let (storage_status, storage_message) = match persistence::check_disk_space(&storage_path, 1) {
+        Ok(()) => ("ok".to_string(), None),
+        Err(message) => ("error".to_string(), Some(message)),
+    };
+
+    let status = if settings_ok && !index_version_mismatch && storage_status == "ok" {
+        "ok"
+    } else {
+        "degraded"
+    }
+    .to_string();
+
+    Ok(HealthCheckResponse {
+        status,
+        search_session_status,
+        active_search_id: search_snapshot.active_search_id,
+        index_status,
+        index_entries,
+        index_roots,
+        index_version_mismatch,
+        index_rebuild_in_progress,
+        index_rebuild_entries_count,
+        settings_status,
+        cache_status,
+        storage_status,
+        storage_path: storage_path.to_string_lossy().to_string(),
+        storage_message,
+    })
+}
+
+fn command_status_label(status: &CommandStatus) -> &'static str {
+    match status {
+        CommandStatus::Idle => "idle",
+        CommandStatus::Accepted => "accepted",
+        CommandStatus::Cancelled => "cancelled",
+        CommandStatus::NotFound => "not_found",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::persistence::with_test_data_dir;
+
+    #[test]
+    fn health_check_reports_default_state() {
+        with_test_data_dir(|| {
+            let state = AppState::bootstrap();
+            let health = health_check_inner(&state).expect("health");
+
+            assert_eq!(health.status, "ok");
+            assert_eq!(health.search_session_status, "idle");
+            assert_eq!(health.index_status, "empty");
+            assert_eq!(health.settings_status, "ok");
+            assert_eq!(health.cache_status, "idle");
+            assert_eq!(health.storage_status, "ok");
+            assert!(health.storage_message.is_none());
+            assert!(!health.storage_path.is_empty());
+        });
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod actions;
 pub mod errors;
 pub mod favorites;
+pub mod health;
 pub mod history;
 pub mod index;
 pub mod profiles;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,7 +5,7 @@ mod core;
 mod platform;
 mod storage;
 
-use commands::{actions, favorites, history, index, profiles, search, settings};
+use commands::{actions, favorites, health, history, index, profiles, search, settings};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::Arc;
@@ -124,6 +124,7 @@ fn main() {
       actions::batch_delete,
       actions::export_search_results,
       actions::export_to_clipboard,
+      health::health_check,
       index::index_rebuild,
       index::index_rebuild_cancel,
       index::index_status

--- a/src/app/hooks/useApp.ts
+++ b/src/app/hooks/useApp.ts
@@ -15,6 +15,7 @@ import {
   favoritesAdd,
   favoritesRemove,
   fsPickFolder,
+  healthCheck,
   indexRebuildCancel,
   onSearchBatch,
   onSearchCancelled,
@@ -534,9 +535,31 @@ export function useApp() {
     }
   }, [pushToast, tr]);
 
+  const handleHealthCheck = useCallback(async (): Promise<void> => {
+    if (!tauriRuntimeAvailable) {
+      pushToast(tr("app.status.tauriUnavailable", "Tauri runtime не обнаружен"), "error");
+      return;
+    }
+
+    try {
+      const health = await healthCheck();
+      pushToast(
+        tr("app.toast.healthCheck", "Health: {{status}} · index {{index}} · storage {{storage}}", {
+          status: health.status,
+          index: health.index_status,
+          storage: health.storage_status,
+        }),
+        health.status === "ok" ? "success" : "error"
+      );
+    } catch {
+      pushToast(tr("app.toast.healthCheckFailed", "Не удалось выполнить health check"), "error");
+    }
+  }, [pushToast, tr]);
+
   const commandActions = useMemo(() => [
     { id: "cmd-new", label: tr("app.commands.newSearch", "> Новый поиск"), run: () => void handleSearch() },
     { id: "cmd-rebuild-index", label: tr("app.commands.rebuildIndex", "> Перестроить индекс"), run: () => void index.handleRebuildIndex(indexRoots) },
+    { id: "cmd-health-check", label: tr("app.commands.healthCheck", "> Health check"), run: () => void handleHealthCheck() },
     { id: "cmd-clear-history", label: tr("app.commands.clearHistory", "> Очистить историю"), run: requestClearHistory },
     { id: "cmd-theme", label: tr("app.commands.toggleTheme", "> Переключить тему"), run: () => themeState.setThemeId((prev) => (prev === "dark" ? "light" : "dark")) },
     { id: "cmd-focus", label: tr("app.commands.focusSearch", "/ Фокус в строку поиска"), run: () => searchInputRef.current?.focus() },
@@ -546,7 +569,7 @@ export function useApp() {
       label: `# ${profile.name}`,
       run: () => applyProfile(profile)
     }))
-  ], [handleSearch, index, indexRoots, requestClearHistory, themeState, pushToast, tr, persistence.profiles, applyProfile]);
+  ], [handleSearch, index, indexRoots, handleHealthCheck, requestClearHistory, themeState, pushToast, tr, persistence.profiles, applyProfile]);
 
   useEffect(() => {
     searchInputRef.current?.focus();

--- a/src/shared/search-types.ts
+++ b/src/shared/search-types.ts
@@ -180,6 +180,23 @@ export interface IndexStatusResponse {
   rebuild_entries_count: number;
 }
 
+export interface HealthCheckResponse {
+  status: "ok" | "degraded";
+  search_session_status: string;
+  active_search_id: number | null;
+  index_status: "empty" | "ready" | "in_progress" | "version_mismatch";
+  index_entries: number;
+  index_roots: number;
+  index_version_mismatch: boolean;
+  index_rebuild_in_progress: boolean;
+  index_rebuild_entries_count: number;
+  settings_status: string;
+  cache_status: string;
+  storage_status: string;
+  storage_path: string;
+  storage_message: string | null;
+}
+
 export interface IndexRebuildResponse {
   status: string;
   roots: number;

--- a/src/shared/tauri-client.ts
+++ b/src/shared/tauri-client.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type {
   FsTreeNode,
+  HealthCheckResponse,
   HistorySnapshot,
   IndexProgressEvent,
   IndexDoneEvent,
@@ -201,6 +202,10 @@ export async function contentSearch(
   useRegex: boolean
 ): Promise<import("./search-types").ContentSearchResponse> {
   return invoke("content_search", { paths, query, caseSensitive, wholeWord, useRegex });
+}
+
+export async function healthCheck(): Promise<HealthCheckResponse> {
+  return invoke<HealthCheckResponse>("health_check");
 }
 
 export async function indexStatus(): Promise<IndexStatusResponse> {


### PR DESCRIPTION
## Summary
- add a `health_check` Tauri command covering search session, index, settings, cache, and storage state
- wire the command through the shared Tauri client/types
- add a Command Palette action that runs the check and reports the result in a toast

## Validation
- cargo test --manifest-path src-tauri/Cargo.toml health_check
- pnpm install --frozen-lockfile
- pnpm run check
- pnpm run test
- pnpm run build
- git diff --check

Closes #105.
