### PR TITLE
fix: debounce live search requests

### DIFF
--- a/src/app/hooks/useApp.ts
+++ b/src/app/hooks/useApp.ts
@@ -81,6 +81,9 @@ export function useApp() {
   
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const resultPaneRef = useRef<HTMLDivElement | null>(null);
+  const liveSearchTimerRef = useRef<number | null>(null);
+  const runSearchRef = useRef<((preparedRequest?: SearchRequest) => Promise<void>) | null>(null);
+  const incrementalSearchRef = useRef<(request: SearchRequest) => boolean>(() => false);
 
   const indexRoots = useMemo(
     () => roots.enabledRoots.length > 0 ? roots.enabledRoots : [roots.primaryRoot].filter(Boolean),
@@ -272,11 +275,20 @@ export function useApp() {
     return true;
   }, [searchState, searchRefs, uiState, tr, incrementalSearch]);
 
+  const clearLiveSearchTimer = useCallback(() => {
+    if (liveSearchTimerRef.current !== null) {
+      window.clearTimeout(liveSearchTimerRef.current);
+      liveSearchTimerRef.current = null;
+    }
+  }, []);
+
   const handleSearch = useCallback(async (preparedRequest?: SearchRequest): Promise<void> => {
     if (!tauriRuntimeAvailable) {
       searchState.setStatus(tr("app.status.tauriUnavailable", "Tauri runtime не обнаружен"));
       return;
     }
+
+    clearLiveSearchTimer();
 
     if (searchState.isSearching) {
       return;
@@ -333,7 +345,15 @@ export function useApp() {
       searchState.setStatus(tr("app.status.startError", "Ошибка запуска: {{error}}", { error: String(error) }));
       pushToast(tr("app.toast.searchStartFailed", "Не удалось запустить поиск"), "error");
     }
-  }, [searchState, searchRefs, uiState, validateCurrentDateFilters, buildCurrentRequest, pushToast, tr]);
+  }, [searchState, searchRefs, uiState, validateCurrentDateFilters, buildCurrentRequest, pushToast, tr, clearLiveSearchTimer]);
+
+  useEffect(() => {
+    runSearchRef.current = handleSearch;
+  }, [handleSearch]);
+
+  useEffect(() => {
+    incrementalSearchRef.current = tryIncrementalPlainSearch;
+  }, [tryIncrementalPlainSearch]);
 
   const handleCancel = useCallback(async (): Promise<void> => {
     if (!tauriRuntimeAvailable) return;
@@ -737,53 +757,19 @@ export function useApp() {
   }, [tr, scheduleResultsFlush, persistence, searchState, searchRefs]);
 
   useEffect(() => {
+    clearLiveSearchTimer();
     if (!settingsState.liveSearch) return;
     const request = buildCurrentRequest();
     if (!request.query.trim()) return;
-    const adaptiveDebounce = computeAdaptiveDebounce(request, settingsState.debounceMs);
-    const timer = window.setTimeout(() => {
-      if (tryIncrementalPlainSearch(request)) return;
-      void handleSearch(request);
-    }, adaptiveDebounce);
-    return () => window.clearTimeout(timer);
-  }, [settingsState.debounceMs, settingsState.liveSearch, query, filterState.searchBackend, buildCurrentRequest, handleSearch, tryIncrementalPlainSearch]);
 
-  useEffect(() => {
-    if (!settingsState.liveSearch) return;
-    const request = buildCurrentRequest();
-    if (!request.query.trim()) return;
-    const timer = window.setTimeout(() => {
-      void handleSearch(request);
-    }, settingsState.debounceMs);
-    return () => window.clearTimeout(timer);
-  }, [
-    filterState.createdAfter,
-    filterState.createdBefore,
-    filterState.createdFilterEnabled,
-    filterState.entryKind,
-    filterState.extensionsRaw,
-    filterState.excludePathsRaw,
-    filterState.ignoreCase,
-    filterState.includeHidden,
-    limit,
-    filterState.matchMode,
-    filterState.maxDepth,
-    filterState.maxDepthUnlimited,
-    filterState.modifiedAfter,
-    filterState.modifiedBefore,
-    filterState.modifiedFilterEnabled,
-    settingsState.regexEnabled,
-    roots.roots,
-    filterState.sizeComparison,
-    filterState.sizeFilterEnabled,
-    filterState.sizeUnit,
-    filterState.sizeValue,
-    filterState.strict,
-    settingsState.debounceMs,
-    settingsState.liveSearch,
-    buildCurrentRequest,
-    handleSearch
-  ]);
+    liveSearchTimerRef.current = window.setTimeout(() => {
+      liveSearchTimerRef.current = null;
+      if (incrementalSearchRef.current(request)) return;
+      void runSearchRef.current?.(request);
+    }, computeAdaptiveDebounce(request, settingsState.debounceMs));
+
+    return clearLiveSearchTimer;
+  }, [settingsState.debounceMs, settingsState.liveSearch, buildCurrentRequest, clearLiveSearchTimer]);
 
   useEffect(() => {
     if (!tauriRuntimeAvailable || searchState.isSearching || layoutState.displayMode === "cards" || visibleRows.items.length === 0) return;

--- a/src/app/hooks/useSearchRequest.ts
+++ b/src/app/hooks/useSearchRequest.ts
@@ -12,69 +12,99 @@ type UseSearchRequestOptions = Omit<BuildSearchRequestInput, "enabledRoots" | "p
 export type { DateValidationError };
 
 export function useSearchRequest(options: UseSearchRequestOptions) {
+  const {
+    query,
+    enabledRoots,
+    primaryRoot,
+    extensionsRaw,
+    excludePathsRaw,
+    maxDepthUnlimited,
+    maxDepth,
+    limit,
+    strict,
+    ignoreCase,
+    includeHidden,
+    entryKind,
+    matchMode,
+    sizeFilterEnabled,
+    sizeComparison,
+    sizeValue,
+    sizeUnit,
+    modifiedFilterEnabled,
+    modifiedAfter,
+    modifiedBefore,
+    createdFilterEnabled,
+    createdAfter,
+    createdBefore,
+    sortMode,
+    searchBackend
+  } = options;
+
+  const requestInput = useMemo<BuildSearchRequestInput>(() => ({
+    query,
+    enabledRoots,
+    primaryRoot: primaryRoot ?? "",
+    extensionsRaw,
+    excludePathsRaw,
+    maxDepthUnlimited,
+    maxDepth,
+    limit,
+    strict,
+    ignoreCase,
+    includeHidden,
+    entryKind,
+    matchMode,
+    sizeFilterEnabled,
+    sizeComparison,
+    sizeValue,
+    sizeUnit,
+    modifiedFilterEnabled,
+    modifiedAfter,
+    modifiedBefore,
+    createdFilterEnabled,
+    createdAfter,
+    createdBefore,
+    sortMode,
+    searchBackend
+  }), [
+    query,
+    enabledRoots,
+    primaryRoot,
+    extensionsRaw,
+    excludePathsRaw,
+    maxDepthUnlimited,
+    maxDepth,
+    limit,
+    strict,
+    ignoreCase,
+    includeHidden,
+    entryKind,
+    matchMode,
+    sizeFilterEnabled,
+    sizeComparison,
+    sizeValue,
+    sizeUnit,
+    modifiedFilterEnabled,
+    modifiedAfter,
+    modifiedBefore,
+    createdFilterEnabled,
+    createdAfter,
+    createdBefore,
+    sortMode,
+    searchBackend
+  ]);
+
   const buildCurrentRequest = useCallback((): SearchRequest => {
-    return buildSearchRequest({
-      query: options.query,
-      enabledRoots: options.enabledRoots,
-      primaryRoot: options.primaryRoot ?? "",
-      extensionsRaw: options.extensionsRaw,
-      excludePathsRaw: options.excludePathsRaw,
-      maxDepthUnlimited: options.maxDepthUnlimited,
-      maxDepth: options.maxDepth,
-      limit: options.limit,
-      strict: options.strict,
-      ignoreCase: options.ignoreCase,
-      includeHidden: options.includeHidden,
-      entryKind: options.entryKind,
-      matchMode: options.matchMode,
-      sizeFilterEnabled: options.sizeFilterEnabled,
-      sizeComparison: options.sizeComparison,
-      sizeValue: options.sizeValue,
-      sizeUnit: options.sizeUnit,
-      modifiedFilterEnabled: options.modifiedFilterEnabled,
-      modifiedAfter: options.modifiedAfter,
-      modifiedBefore: options.modifiedBefore,
-      createdFilterEnabled: options.createdFilterEnabled,
-      createdAfter: options.createdAfter,
-      createdBefore: options.createdBefore,
-      sortMode: options.sortMode,
-      searchBackend: options.searchBackend
-    });
-  }, [options]);
+    return buildSearchRequest(requestInput);
+  }, [requestInput]);
 
   const validateDateFilters = useCallback((): DateValidationError[] => {
-    return getDateValidationErrors({
-      query: options.query,
-      enabledRoots: options.enabledRoots,
-      primaryRoot: options.primaryRoot ?? "",
-      extensionsRaw: options.extensionsRaw,
-      excludePathsRaw: options.excludePathsRaw,
-      maxDepthUnlimited: options.maxDepthUnlimited,
-      maxDepth: options.maxDepth,
-      limit: options.limit,
-      strict: options.strict,
-      ignoreCase: options.ignoreCase,
-      includeHidden: options.includeHidden,
-      entryKind: options.entryKind,
-      matchMode: options.matchMode,
-      sizeFilterEnabled: options.sizeFilterEnabled,
-      sizeComparison: options.sizeComparison,
-      sizeValue: options.sizeValue,
-      sizeUnit: options.sizeUnit,
-      modifiedFilterEnabled: options.modifiedFilterEnabled,
-      modifiedAfter: options.modifiedAfter,
-      modifiedBefore: options.modifiedBefore,
-      createdFilterEnabled: options.createdFilterEnabled,
-      createdAfter: options.createdAfter,
-      createdBefore: options.createdBefore,
-      sortMode: options.sortMode,
-      searchBackend: options.searchBackend
-    });
-  }, [options]);
+    return getDateValidationErrors(requestInput);
+  }, [requestInput]);
 
   const isEmptyQuery = useMemo(
-    () => !options.query.trim(),
-    [options.query]
+    () => !query.trim(),
+    [query]
   );
 
   return {

--- a/src/app/search-utils.test.ts
+++ b/src/app/search-utils.test.ts
@@ -179,7 +179,7 @@ describe("computeAdaptiveDebounce", () => {
     expect(result).toBeLessThanOrEqual(300);
   });
 
-  it("clamps debounce for short simple queries", () => {
+  it("does not shorten the configured debounce for short simple queries", () => {
     const request = {
       options: { match_mode: "Plain", max_depth: null, size_filter: null, created_filter: null, modified_filter: null },
       query: "abc",
@@ -187,8 +187,7 @@ describe("computeAdaptiveDebounce", () => {
       extensions: []
     };
     const result = computeAdaptiveDebounce(request, 200);
-    expect(result).toBeGreaterThanOrEqual(80);
-    expect(result).toBeLessThanOrEqual(120);
+    expect(result).toBe(200);
   });
 
   it("uses normal range for complex queries", () => {
@@ -201,6 +200,16 @@ describe("computeAdaptiveDebounce", () => {
     const result = computeAdaptiveDebounce(request, 200);
     expect(result).toBeGreaterThanOrEqual(120);
     expect(result).toBeLessThanOrEqual(220);
+  });
+
+  it("keeps long configured debounce values instead of clamping them down", () => {
+    const request = {
+      options: { match_mode: "Regex", max_depth: null, size_filter: null, created_filter: null, modified_filter: null },
+      query: "test",
+      roots: ["/home"],
+      extensions: []
+    };
+    expect(computeAdaptiveDebounce(request, 750)).toBe(750);
   });
 });
 

--- a/src/app/utils/search-utils.ts
+++ b/src/app/utils/search-utils.ts
@@ -145,14 +145,15 @@ export function sameSearchContextWithoutQuery(left: { roots: string[]; extension
 
 /**
  * Computes adaptive debounce delay based on search complexity.
- * Uses shorter delays for simple queries, longer for complex searches.
+ * Never schedules faster than the configured debounce value.
  */
 export function computeAdaptiveDebounce(request: { options: { match_mode: string; max_depth: number | null; size_filter: unknown; created_filter: unknown; modified_filter: unknown }; query: string; roots: string[]; extensions: string[] }, configuredDebounceMs: number): number {
+  const configured = clamp(Math.round(configuredDebounceMs), 100, 2000);
   const mode = request.options.match_mode;
   const heavyMode = mode === "Regex" || mode === "Wildcard";
   const manyRoots = request.roots.length >= 3;
   if (heavyMode || manyRoots) {
-    return clamp(configuredDebounceMs, 200, 300);
+    return Math.max(configured, 300);
   }
 
   const shortPlainQuery = mode === "Plain" && request.query.trim().length <= 5;
@@ -163,10 +164,10 @@ export function computeAdaptiveDebounce(request: { options: { match_mode: string
     request.options.created_filter === null &&
     request.options.modified_filter === null;
   if (shortPlainQuery && noHeavyFilters) {
-    return clamp(configuredDebounceMs, 80, 120);
+    return configured;
   }
 
-  return clamp(configuredDebounceMs, 120, 220);
+  return Math.max(configured, 150);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Consolidate live search into one debounced scheduler so query and filter changes do not create duplicate search timers.
- Stabilize search request callbacks so unrelated renders do not reset pending live-search debounce.
- Keep the configured debounce value as the minimum delay when applying adaptive debounce logic.

Closes #115

## Validation
- pnpm run check
- pnpm run test
- pnpm run build
- cargo test

Note: `cargo clippy -- -D warnings` currently fails on unrelated existing Rust warnings/dead code/derivable impls, so I left that cleanup out of this frontend PR.